### PR TITLE
Construct query without repeats

### DIFF
--- a/src/Box/Services/Folders/FolderService.php
+++ b/src/Box/Services/Folders/FolderService.php
@@ -87,21 +87,27 @@ class FolderService extends BaseService
         Assert::integerish($limit, "The limit must be an integer. Got: %s");
         Assert::integerish($offset, "The offset must be an integer. Got: %s");
 
-        $query_fields = "?fields=";
+        $query_fields = array(
+          'fields' => array(),
+        );
 
-        foreach ($fields as $field) {
-            if (trim($field)) {
-                $query_fields = $query_fields . $field . ",";
-            }
+        if (!empty($fields)) {
+          foreach ($fields as $field) {
+              if (trim($field)) {
+                  $query_fields['fields'][] = trim($field);
+              }
+          }
+        } else {
+          unset($query_fields['fields']);
         }
 
-        $query_fields .= rtrim($query_fields, ',');
-        $query_fields .= "&limit=" . $limit;
-        $query_fields .= "&offset=" . $offset;
+        $query_fields['limit'] = $limit;
+        $query_fields['offset'] = $offset;
 
+        $query = http_build_query($query_fields);
         return $this->guzzle_client->request(
             'GET',
-            BAP::BASE_FOLDER_URL . BAP::URL_SEPARATOR . $folder_id . BAP::URL_SEPARATOR . "items" . $query_fields,
+            BAP::BASE_FOLDER_URL . BAP::URL_SEPARATOR . $folder_id . BAP::URL_SEPARATOR . "items" . '?' . $query,
             [
                 'headers' => [
                     "Authorization" => "Bearer " . $this->app_auth->getTokenInfo()->access_token


### PR DESCRIPTION
There was an error where the query_fields string was concatenating
with itself. It caused queries like this:
https://api.box.com/2.0/folders/[id]/items?fields=?fields=&limit=100&offset=0

Using internal PHP http_build_query function makes the queries neater.