### PR TITLE
(HOTFIX) Use absolute path instead of prefixing it with getcwd

### DIFF
--- a/src/Box/Auth/AppAuth.php
+++ b/src/Box/Auth/AppAuth.php
@@ -61,11 +61,11 @@ class AppAuth
         $this->claim = $claim;
 
         // $key Has to be the key file handler opened using openssl method
-        $key = openssl_get_privatekey("file://" . getcwd() . '/' . $this->private_key, $this->pass_phrase);
+        $key = openssl_get_privatekey("file://" . $this->private_key, $this->pass_phrase);
 
         if ($key === false) {
             // TODO: Move to separate exception
-            throw new \Exception('Could not read key from "' . "file://" . getcwd() . '/' . $this->private_key . '" with pass phrase "' . $this->pass_phrase . '"');
+            throw new \Exception('Could not read key from "' . "file://" . $this->private_key . '" with pass phrase "' . $this->pass_phrase . '"');
         }
 
         $token = $claim->toArray();


### PR DESCRIPTION
Hi there,

Before anything else, thank you for this contribution -- I'm currently using it for this [Laravel service provider](https://github.com/jpcaparas/box-laravel). It's a life saver considering that Box.com doesn't provide an official PHP SDK 🙃 and they're forcing everyone to migrate to the New Box View.

Going back to this PR, I actually had issues getting authentication to work when keying in an absolute path for the private key because it got prefixed by `getcwd`. Removing that function fixes the issue and makes the app authenticate properly.

Hopefully, you consider my PR.

Thanks,
JP